### PR TITLE
Improve audio playback stability using streaming AudioClip

### DIFF
--- a/Plugin~/WebRTCPlugin/Context.h
+++ b/Plugin~/WebRTCPlugin/Context.h
@@ -143,6 +143,9 @@ namespace webrtc
         void SetEncoderParameter(const MediaStreamTrackInterface* track, int width, int height,
             UnityRenderingExtTextureFormat format, void* textureHandle);
 
+        // AudioDevice
+        rtc::scoped_refptr<DummyAudioDevice> GetAudioDevice() const { return m_audioDevice; }
+
         // mutex;
         std::mutex mutex;
 

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "DummyAudioDevice.h"
+#include "UnityAudioTrackSource.h"
 #include "system_wrappers/include/sleep.h"
 
 namespace unity
@@ -56,31 +57,8 @@ namespace webrtc
             const int64_t bgnTime = rtc::TimeMillis();
             {
                 std::lock_guard<std::mutex> lock(mutex_);
-
-                if (sampleRate_ > 0 && channels_ > 0) {
-                    const size_t samplesFor10ms = sampleRate_ * channels_ / 100;
-
-                    if (buffer_init == false && audioBuffer_.size() > samplesFor10ms * 10) {
-                        audioBuffer_.erase(
-                            audioBuffer_.begin(),
-                            audioBuffer_.begin() + (audioBuffer_.size() - samplesFor10ms));
-                        buffer_init = true;
-                    }
-
-                    if (buffer_init) {
-                        if (audioBuffer_.size() >= samplesFor10ms) {
-                            constexpr int bytePerSample = sizeof(decltype(audioBuffer_)::value_type);
-
-                            uint32_t newMicLev = 0;
-                            if (audio_transport_) {
-                                (*audio_transport_).RecordedDataIsAvailable(audioBuffer_.data(),
-                                    sampleRate_ / 100, bytePerSample, channels_, sampleRate_,
-                                    0, 0, 0, false, newMicLev);
-                            }
-
-                            audioBuffer_.erase(audioBuffer_.begin(), audioBuffer_.begin() + samplesFor10ms);
-                        }
-                    }
+                for (const auto &pair : callbacks_) {
+                    pair.second();
                 }
             }
             if (recording_) {
@@ -92,23 +70,11 @@ namespace webrtc
         }
     }
 
-    void DummyAudioDevice::InitLocalAudio(int sampleRate, int channels) {
-        std::lock_guard<std::mutex> lock(mutex_);
-
-        sampleRate_ = sampleRate;
-        channels_ = channels;
-    }
-    
-    void DummyAudioDevice::PushLocalAudio(const float* audioData, int sampleRate, int channels, int numFrames) {
-        std::lock_guard<std::mutex> lock(mutex_);
-
-        if (sampleRate_ == 0 || channels_ == 0)
-            return;
-
-        audioBuffer_.reserve(audioBuffer_.size() + numFrames);
-        for (size_t i = 0; i < numFrames; i++)
-        {
-            audioBuffer_.push_back(audioData[i] >= 0 ? audioData[i] * SHRT_MAX : audioData[i] * -SHRT_MIN);
+    void DummyAudioDevice::RegisterSendAudioCallback(UnityAudioTrackSource* source, int sampleRate, int channels) {
+        if (callbacks_.find(source) == callbacks_.end()) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            callbacks_.emplace(source, [source, sampleRate, channels]() {
+                source->SendAudioData(sampleRate, channels); });
         }
     }
 

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
@@ -50,7 +50,7 @@ namespace webrtc
         return true;
     }
 
-    void DummyAudioDevice::RecodingThread() {
+    void DummyAudioDevice::RecordingThread() {
         bool buffer_init = false;
 
         while (recording_) {

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.cpp
@@ -12,8 +12,6 @@ namespace webrtc
         int64_t currentTime = rtc::TimeMillis();
 
         {
-            std::lock_guard<std::mutex> lock(mutex_);
-
             if (audio_transport_ == nullptr) {
                 return false;
             }
@@ -38,13 +36,80 @@ namespace webrtc
                 int64_t ntp_time_ms = -1;
                 char data[kBytesPerSample * kChannels * kSamplesPerFrame];
 
-                audio_transport_->PullRenderData(kBytesPerSample * 8, kSamplingRate,
+                (*audio_transport_).PullRenderData(kBytesPerSample * 8, kSamplingRate,
                     kChannels, kSamplesPerFrame, data,
                     &elapsed_time_ms, &ntp_time_ms);
             }
         }
 
+        int64_t deltaTimeMillis = rtc::TimeMillis() - currentTime;
+        if (deltaTimeMillis < 10) {
+            SleepMs(10 - (deltaTimeMillis + 1));
+        }
         return true;
+    }
+
+    void DummyAudioDevice::RecodingThread() {
+        bool buffer_init = false;
+
+        while (recording_) {
+            const int64_t bgnTime = rtc::TimeMillis();
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+
+                if (sampleRate_ > 0 && channels_ > 0) {
+                    const size_t samplesFor10ms = sampleRate_ * channels_ / 100;
+
+                    if (buffer_init == false && audioBuffer_.size() > samplesFor10ms * 10) {
+                        audioBuffer_.erase(
+                            audioBuffer_.begin(),
+                            audioBuffer_.begin() + (audioBuffer_.size() - samplesFor10ms));
+                        buffer_init = true;
+                    }
+
+                    if (buffer_init) {
+                        if (audioBuffer_.size() >= samplesFor10ms) {
+                            constexpr int bytePerSample = sizeof(decltype(audioBuffer_)::value_type);
+
+                            uint32_t newMicLev = 0;
+                            if (audio_transport_) {
+                                (*audio_transport_).RecordedDataIsAvailable(audioBuffer_.data(),
+                                    sampleRate_ / 100, bytePerSample, channels_, sampleRate_,
+                                    0, 0, 0, false, newMicLev);
+                            }
+
+                            audioBuffer_.erase(audioBuffer_.begin(), audioBuffer_.begin() + samplesFor10ms);
+                        }
+                    }
+                }
+            }
+            if (recording_) {
+                const int64_t elapsed = rtc::TimeMillis() - bgnTime;
+                if (elapsed < 10) {
+                    SleepMs(10 - (elapsed + 1));
+                }
+            }
+        }
+    }
+
+    void DummyAudioDevice::InitLocalAudio(int sampleRate, int channels) {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        sampleRate_ = sampleRate;
+        channels_ = channels;
+    }
+    
+    void DummyAudioDevice::PushLocalAudio(const float* audioData, int sampleRate, int channels, int numFrames) {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        if (sampleRate_ == 0 || channels_ == 0)
+            return;
+
+        audioBuffer_.reserve(audioBuffer_.size() + numFrames);
+        for (size_t i = 0; i < numFrames; i++)
+        {
+            audioBuffer_.push_back(audioData[i] >= 0 ? audioData[i] * SHRT_MAX : audioData[i] * -SHRT_MIN);
+        }
     }
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.h
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mutex>
+#include <unordered_map>
 
 #include "WebRTCPlugin.h"
 #include "api/task_queue/default_task_queue_factory.h"
@@ -11,6 +12,8 @@ namespace unity
 namespace webrtc
 {
     using namespace ::webrtc;
+
+    class UnityAudioTrackSource;
 
     class DummyAudioDevice : public webrtc::AudioDeviceModule
     {
@@ -319,8 +322,7 @@ namespace webrtc
             return 0;
         }
 #endif
-        void InitLocalAudio(int sampleRate, int channels);
-        void PushLocalAudio(const float* audioData, int sampleRate, int channels, int numFrames);
+        void RegisterSendAudioCallback(UnityAudioTrackSource* source, int sampleRate, int channels);
 
     private:
         bool PlayoutThreadProcess();
@@ -336,9 +338,8 @@ namespace webrtc
 
         std::atomic<webrtc::AudioTransport*> audio_transport_{ nullptr };
 
-        int sampleRate_ = 0;
-        int channels_ = 0;
-        std::vector<int16_t> audioBuffer_;
+        using callback_t = std::function<void()>;
+        std::unordered_map<UnityAudioTrackSource*, callback_t> callbacks_;
     };
 
 } // end namespace webrtc

--- a/Plugin~/WebRTCPlugin/DummyAudioDevice.h
+++ b/Plugin~/WebRTCPlugin/DummyAudioDevice.h
@@ -142,7 +142,7 @@ namespace webrtc
         {
             recording_ = true;
             recordAudioThread_.reset(new rtc::PlatformThread(
-                [](void *pThis) { static_cast<DummyAudioDevice*>(pThis)->RecodingThread(); },
+                [](void *pThis) { static_cast<DummyAudioDevice*>(pThis)->RecordingThread(); },
                 this, "webrtc_audio_module_recording_thread", rtc::kRealtimePriority));
             recordAudioThread_->Start();
             return 0;
@@ -326,7 +326,7 @@ namespace webrtc
 
     private:
         bool PlayoutThreadProcess();
-        void RecodingThread();
+        void RecordingThread();
 
         std::atomic<bool> initialized_ {false};
         std::atomic<bool> playing_ {false};

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
@@ -37,44 +37,6 @@ void UnityAudioTrackSource::RemoveSink(AudioTrackSinkInterface* sink)
         _arrSink.erase(i);
 }
 
-void UnityAudioTrackSource::OnData(const float* pAudioData, int nSampleRate, size_t nNumChannels, size_t nNumFrames)
-{
-    RTC_DCHECK(pAudioData);
-    RTC_DCHECK(nSampleRate);
-    RTC_DCHECK(nNumChannels);
-    RTC_DCHECK(nNumFrames);
-
-    std::lock_guard<std::mutex> lock(_mutex);
-
-    if (_arrSink.empty())
-        return;
-
-    for (size_t i = 0; i < nNumFrames; i++)
-    {
-        _convertedAudioData.push_back(pAudioData[i] >= 0 ? pAudioData[i] * SHRT_MAX : pAudioData[i] * -SHRT_MIN);
-    }
-
-    // eg.  80 for 8KHz and 160 for 16kHz
-    size_t nNumFramesFor10ms = nSampleRate / 100;
-    size_t size = _convertedAudioData.size() / (nNumFramesFor10ms * nNumChannels);
-    size_t nBitPerSample = sizeof(int16_t) * 8;
-
-    for(auto sink : _arrSink)
-    {
-        for (size_t i = 0; i < size; i++)
-        {
-            sink->OnData(
-                &_convertedAudioData.data()[i * nNumFramesFor10ms * nNumChannels],
-                nBitPerSample, nSampleRate, nNumChannels, nNumFramesFor10ms);
-        }
-    }
-
-    // pop processed buffer, remained buffer will be processed the next time.
-    _convertedAudioData.erase(
-        _convertedAudioData.begin(),
-        _convertedAudioData.begin() + nNumFramesFor10ms * nNumChannels * size);
-}
-
 UnityAudioTrackSource::UnityAudioTrackSource()
 {
 }

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.cpp
@@ -37,6 +37,56 @@ void UnityAudioTrackSource::RemoveSink(AudioTrackSinkInterface* sink)
         _arrSink.erase(i);
 }
 
+void UnityAudioTrackSource::PushAudioData(const float* pAudioData, int nSampleRate, size_t nNumChannels, size_t nNumFrames)
+{
+    RTC_DCHECK(pAudioData);
+    RTC_DCHECK(nSampleRate);
+    RTC_DCHECK(nNumChannels);
+    RTC_DCHECK(nNumFrames);
+
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    if (_arrSink.empty())
+        return;
+
+    for (size_t i = 0; i < nNumFrames; i++)
+    {
+        _convertedAudioData.push_back(pAudioData[i] >= 0 ? pAudioData[i] * SHRT_MAX : pAudioData[i] * -SHRT_MIN);
+    }
+}
+
+void UnityAudioTrackSource::SendAudioData(int nSampleRate, size_t nNumChannels) {
+    RTC_DCHECK(nSampleRate);
+    RTC_DCHECK(nNumChannels);
+
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    // eg.  80 for 8KHz and 160 for 16kHz
+    size_t nNumFramesFor10ms = nSampleRate / 100;
+    size_t nNumSamplesFor10ms = nNumFramesFor10ms * nNumChannels;
+    size_t nBitPerSample = sizeof(int16_t) * 8;
+
+    if (_bufferInit == false && _convertedAudioData.size() > nNumSamplesFor10ms * 8) {
+        _convertedAudioData.erase(
+            _convertedAudioData.begin(),
+            _convertedAudioData.begin() + (_convertedAudioData.size() - nNumSamplesFor10ms * 8));
+        _bufferInit = true;
+    }
+
+    if (_bufferInit) {
+        for (auto sink : _arrSink)
+        {
+            sink->OnData(_convertedAudioData.data(),
+                nBitPerSample, nSampleRate, nNumChannels, nNumFramesFor10ms);
+        }
+    }
+
+    // pop processed buffer, remained buffer will be processed the next time.
+    _convertedAudioData.erase(
+        _convertedAudioData.begin(),
+        _convertedAudioData.begin() + nNumSamplesFor10ms);
+}
+
 UnityAudioTrackSource::UnityAudioTrackSource()
 {
 }

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
@@ -18,8 +18,6 @@ namespace webrtc
         void AddSink(AudioTrackSinkInterface* sink) override;
         void RemoveSink(AudioTrackSinkInterface* sink) override;
 
-        void OnData(const float* pAudioData, int nSampleRate, size_t nNumChannels, size_t nNumFrames);
-
     protected:
         UnityAudioTrackSource();
         UnityAudioTrackSource(const cricket::AudioOptions& audio_options);

--- a/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
+++ b/Plugin~/WebRTCPlugin/UnityAudioTrackSource.h
@@ -18,6 +18,9 @@ namespace webrtc
         void AddSink(AudioTrackSinkInterface* sink) override;
         void RemoveSink(AudioTrackSinkInterface* sink) override;
 
+        void PushAudioData(const float* pAudioData, int nSampleRate, size_t nNumChannels, size_t nNumFrames);
+        void SendAudioData(int nSampleRate, size_t nNumChannels);
+
     protected:
         UnityAudioTrackSource();
         UnityAudioTrackSource(const cricket::AudioOptions& audio_options);
@@ -29,6 +32,7 @@ namespace webrtc
         std::vector <AudioTrackSinkInterface*> _arrSink;
         std::mutex _mutex;
         cricket::AudioOptions _options;
+        bool _bufferInit = false;
     };
 } // end namespace webrtc
 } // end namespace unity

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1376,27 +1376,26 @@ extern "C"
         ContextManager::GetInstance()->curContext = context;
     }
 
-    UNITY_INTERFACE_EXPORT void ContextInitLocalAudio(
-        Context* context,
-        int32 sample_rate,
-        int32 number_of_channels)
-    {
-        auto adm = context->GetAudioDevice();
-        if (adm != nullptr) {
-            adm->InitLocalAudio(sample_rate, number_of_channels);
-        }
-    }
-
     UNITY_INTERFACE_EXPORT void ContextProcessLocalAudio(
         Context* context,
+        AudioTrackInterface* track,
         float* audio_data,
         int32 sample_rate,
         int32 number_of_channels,
         int32 number_of_frames)
     {
+        UnityAudioTrackSource* source =
+            static_cast<UnityAudioTrackSource*>(track->GetSource());
+
+        source->PushAudioData(
+            audio_data,
+            sample_rate,
+            number_of_channels,
+            number_of_frames);
+
         auto adm = context->GetAudioDevice();
         if (adm != nullptr) {
-            adm->PushLocalAudio(audio_data, sample_rate, number_of_channels, number_of_frames);
+            adm->RegisterSendAudioCallback(source, sample_rate, number_of_channels);
         }
     }
 

--- a/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
+++ b/Plugin~/WebRTCPlugin/WebRTCPlugin.cpp
@@ -1376,22 +1376,29 @@ extern "C"
         ContextManager::GetInstance()->curContext = context;
     }
 
-    UNITY_INTERFACE_EXPORT void ProcessAudio(
-        AudioTrackInterface* track,
+    UNITY_INTERFACE_EXPORT void ContextInitLocalAudio(
+        Context* context,
+        int32 sample_rate,
+        int32 number_of_channels)
+    {
+        auto adm = context->GetAudioDevice();
+        if (adm != nullptr) {
+            adm->InitLocalAudio(sample_rate, number_of_channels);
+        }
+    }
+
+    UNITY_INTERFACE_EXPORT void ContextProcessLocalAudio(
+        Context* context,
         float* audio_data,
         int32 sample_rate,
         int32 number_of_channels,
         int32 number_of_frames)
     {
-        UnityAudioTrackSource* source =
-            static_cast<UnityAudioTrackSource*>(track->GetSource());
-
-        source->OnData(audio_data,
-            sample_rate,
-            number_of_channels,
-            number_of_frames);
+        auto adm = context->GetAudioDevice();
+        if (adm != nullptr) {
+            adm->PushLocalAudio(audio_data, sample_rate, number_of_channels, number_of_frames);
+        }
     }
-
 
     UNITY_INTERFACE_EXPORT void ContextRegisterAudioReceiveCallback(
         Context* context, AudioTrackInterface* track, DelegateAudioReceive callback)

--- a/Runtime/Scripts/AudioSourceRead.cs
+++ b/Runtime/Scripts/AudioSourceRead.cs
@@ -34,6 +34,7 @@ namespace Unity.WebRTC
             sampleRate = clip.frequency;
             nativeArray = new NativeArray<float>(
                 clip.channels * clip.samples, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+            WebRTC.Context.InitLocalAudio(sampleRate, channels);
         }
 
         private void OnDestroy()

--- a/Runtime/Scripts/AudioSourceRead.cs
+++ b/Runtime/Scripts/AudioSourceRead.cs
@@ -34,7 +34,6 @@ namespace Unity.WebRTC
             sampleRate = clip.frequency;
             nativeArray = new NativeArray<float>(
                 clip.channels * clip.samples, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
-            WebRTC.Context.InitLocalAudio(sampleRate, channels);
         }
 
         private void OnDestroy()

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -183,7 +183,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 #endif
@@ -199,7 +199,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 
@@ -213,18 +213,18 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeSlice.GetUnsafeReadOnlyPtr();
-                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
+                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
             }
         }
 
-        static void ProcessAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames)
+        static void ProcessAudio(IntPtr array, int sampleRate, int channels, int frames)
         {
             if (sampleRate == 0 || channels == 0 || frames == 0)
                 throw new ArgumentException($"arguments are invalid values " +
                     $"sampleRate={sampleRate}, " +
                     $"channels={channels}, " +
                     $"frames={frames}");
-            NativeMethods.ProcessAudio(track, array, sampleRate, channels, frames);
+            WebRTC.Context.ProcessLocalAudio(array, sampleRate, channels, frames);
         }
 
         /// <summary>

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -183,7 +183,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 #endif
@@ -199,7 +199,7 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeArray.GetUnsafeReadOnlyPtr();
-                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeArray.Length);
+                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeArray.Length);
             }
         }
 
@@ -213,18 +213,18 @@ namespace Unity.WebRTC
             unsafe
             {
                 void* ptr = nativeSlice.GetUnsafeReadOnlyPtr();
-                ProcessAudio((IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
+                ProcessAudio(GetSelfOrThrow(), (IntPtr)ptr, sampleRate, channels, nativeSlice.Length);
             }
         }
 
-        static void ProcessAudio(IntPtr array, int sampleRate, int channels, int frames)
+        static void ProcessAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames)
         {
             if (sampleRate == 0 || channels == 0 || frames == 0)
                 throw new ArgumentException($"arguments are invalid values " +
                     $"sampleRate={sampleRate}, " +
                     $"channels={channels}, " +
                     $"frames={frames}");
-            WebRTC.Context.ProcessLocalAudio(array, sampleRate, channels, frames);
+            WebRTC.Context.ProcessLocalAudio(track, array, sampleRate, channels, frames);
         }
 
         /// <summary>

--- a/Runtime/Scripts/AudioStreamTrack.cs
+++ b/Runtime/Scripts/AudioStreamTrack.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
@@ -37,10 +38,10 @@ namespace Unity.WebRTC
 
         internal class AudioStreamRenderer : IDisposable
         {
+            private const int SamplesPerSec = 100;
+
             private AudioClip m_clip;
-            private int m_sampleRate;
-            private int m_position = 0;
-            private int m_channel = 0;
+            private readonly BlockingCollection<float[]> m_recvBufs = new BlockingCollection<float[]>(SamplesPerSec);
 
             public AudioClip clip
             {
@@ -50,81 +51,12 @@ namespace Unity.WebRTC
                 }
             }
 
-            private float[] m_buffer;
-            private int m_bufferLength;
-            private int m_bufferPosition;
-            private int m_bufferResetCycle;
-            private int m_bufferingFrame;
-
             public AudioStreamRenderer(string name, int sampleRate, int channels)
             {
-                m_sampleRate = sampleRate;
-                m_channel = channels;
-                int lengthSamples = m_sampleRate;  // sample length for a second
-
-                m_bufferLength = sampleRate * channels;
-                m_buffer = new float[m_bufferLength];
-                m_bufferResetCycle = m_bufferLength * 5;  // reset buffer every 5 seconds
-                m_bufferingFrame = m_sampleRate / 1000;  // set initial buffering frames
+                int lengthSamples = sampleRate / SamplesPerSec;  // sample length for 10 milliseconds
 
                 // note:: OnSendAudio and OnAudioSetPosition callback is called before complete the constructor.
-                m_clip = AudioClip.Create(name, lengthSamples, channels, m_sampleRate, true, OnReadBuffer);
-            }
-
-            internal void OnReadBuffer(float[] data)
-            {
-                int dataLength = data.Length;
-
-                if (m_bufferingFrame > 0)
-                {
-                    m_bufferingFrame -= 1;
-
-                    // Sounds silent while buffering
-                    Array.Clear(data, 0, data.Length);
-                }
-                else if (m_bufferPosition > m_position + dataLength)
-                {
-                    int srcOffset = m_position % m_bufferLength;
-                    int destOffset = 0;
-                    int count = data.Length;
-
-                    if (srcOffset + dataLength > m_bufferLength)
-                    {
-                        count = m_bufferLength - srcOffset;
-
-                        Array.Copy(m_buffer, srcOffset, data, destOffset, count);
-
-                        srcOffset = 0;
-                        destOffset += count;
-                        count = dataLength - count;
-                    }
-
-                    Array.Copy(m_buffer, srcOffset, data, destOffset, count);
-
-                    m_position += dataLength;
-
-                    if (m_position == m_bufferResetCycle)
-                    {
-                        int endPosition = m_bufferPosition;
-                        int startPosition = endPosition - m_position;
-                        int remainLength = endPosition - startPosition;
-
-                        float[] temp = new float[remainLength];
-                        Array.Copy(m_buffer, startPosition, temp, 0, remainLength);
-                        Array.Copy(temp, m_buffer, remainLength);
-
-                        m_position = 0;
-                        m_bufferPosition = remainLength;
-                    }
-                }
-                else
-                {
-                    // Set waiting frames for buffering
-                    m_bufferingFrame += m_sampleRate / 1000; // if 48Khz, then 48 frames
-
-                    // Sounds silent while buffering
-                    Array.Clear(data, 0, data.Length);
-                }
+                m_clip = AudioClip.Create(name, lengthSamples, channels, sampleRate, true, OnAudioRead);
             }
 
             public void Dispose()
@@ -134,35 +66,33 @@ namespace Unity.WebRTC
                     WebRTC.DestroyOnMainThread(m_clip);
                 }
                 m_clip = null;
+                m_recvBufs.Dispose();
             }
 
             internal void SetData(float[] data)
             {
-                int dataLength = data.Length;
-                int srcOffset = 0;
-                int destOffset = m_bufferPosition % m_bufferLength;
-                int count = data.Length;
-
-                if (destOffset + dataLength > m_bufferLength)
-                {
-                    count = m_bufferLength - destOffset;
-
-                    Array.Copy(data, srcOffset, m_buffer, destOffset, count);
-
-                    srcOffset += count;
-                    destOffset = 0;
-
-                    count = dataLength - count;
-                }
-
-                Array.Copy(data, srcOffset, m_buffer, destOffset, count);
-
-                m_bufferPosition += dataLength;
+                m_recvBufs.TryAdd(data);
             }
 
-            internal bool IsValid(int sampleRate, int channels)
+            internal void OnAudioRead(float[] data)
             {
-                return (m_sampleRate == sampleRate && m_channel == channels);
+                if (m_recvBufs == null || m_clip == null)
+                {
+                    return;
+                }
+
+                int remain = data.Length;
+                while (remain > 0)
+                {
+                    if (m_recvBufs.TryTake(out float[] src) == false)
+                    {
+                        return;
+                    }
+
+                    var copyLen = Math.Min(src.Length, remain);
+                    Buffer.BlockCopy(src, 0, data, (data.Length - remain) * sizeof(float), copyLen * sizeof(float));
+                    remain -= copyLen;
+                }
             }
         }
 
@@ -320,13 +250,6 @@ namespace Unity.WebRTC
                     frameCountReceiveDataForIgnoring++;
                     return;
                 }
-                _streamRenderer = new AudioStreamRenderer(this.Id, sampleRate, channels);
-
-                OnAudioReceived?.Invoke(_streamRenderer.clip);
-            }
-            else if (!_streamRenderer.IsValid(sampleRate, channels))
-            {
-                _streamRenderer.Dispose();
                 _streamRenderer = new AudioStreamRenderer(this.Id, sampleRate, channels);
 
                 OnAudioReceived?.Invoke(_streamRenderer.clip);

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -303,5 +303,15 @@ namespace Unity.WebRTC
             textureUpdateFunction = textureUpdateFunction == IntPtr.Zero ? GetUpdateTextureFunc() : textureUpdateFunction;
             VideoDecoderMethods.UpdateRendererTexture(textureUpdateFunction, texture, rendererId);
         }
+
+        internal void InitLocalAudio(int sampleRate, int channels)
+        {
+            NativeMethods.ContextInitLocalAudio(self, sampleRate, channels);
+        }
+
+        internal void ProcessLocalAudio(IntPtr array, int sampleRate, int channels, int frames)
+        {
+            NativeMethods.ContextProcessLocalAudio(self, array, sampleRate, channels, frames);
+        }
     }
 }

--- a/Runtime/Scripts/Context.cs
+++ b/Runtime/Scripts/Context.cs
@@ -304,14 +304,9 @@ namespace Unity.WebRTC
             VideoDecoderMethods.UpdateRendererTexture(textureUpdateFunction, texture, rendererId);
         }
 
-        internal void InitLocalAudio(int sampleRate, int channels)
+        internal void ProcessLocalAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames)
         {
-            NativeMethods.ContextInitLocalAudio(self, sampleRate, channels);
-        }
-
-        internal void ProcessLocalAudio(IntPtr array, int sampleRate, int channels, int frames)
-        {
-            NativeMethods.ContextProcessLocalAudio(self, array, sampleRate, channels, frames);
+            NativeMethods.ContextProcessLocalAudio(self, track, array, sampleRate, channels, frames);
         }
     }
 }

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1085,9 +1085,7 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
-        public static extern void ContextInitLocalAudio(IntPtr context, int sampleRate, int channels);
-        [DllImport(WebRTC.Lib)]
-        public static extern void ContextProcessLocalAudio(IntPtr context, IntPtr array, int sampleRate, int channels, int frames);
+        public static extern void ContextProcessLocalAudio(IntPtr context, IntPtr track, IntPtr array, int sampleRate, int channels, int frames);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsReportGetStatsList(IntPtr report, out ulong length, ref IntPtr types);
         [DllImport(WebRTC.Lib)]

--- a/Runtime/Scripts/WebRTC.cs
+++ b/Runtime/Scripts/WebRTC.cs
@@ -1085,7 +1085,9 @@ namespace Unity.WebRTC
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr GetUpdateTextureFunc(IntPtr context);
         [DllImport(WebRTC.Lib)]
-        public static extern void ProcessAudio(IntPtr track, IntPtr array, int sampleRate, int channels, int frames);
+        public static extern void ContextInitLocalAudio(IntPtr context, int sampleRate, int channels);
+        [DllImport(WebRTC.Lib)]
+        public static extern void ContextProcessLocalAudio(IntPtr context, IntPtr array, int sampleRate, int channels, int frames);
         [DllImport(WebRTC.Lib)]
         public static extern IntPtr StatsReportGetStatsList(IntPtr report, out ulong length, ref IntPtr types);
         [DllImport(WebRTC.Lib)]


### PR DESCRIPTION
In order to reduce latency and improve playback quality, I tried to change to work AudioClip of AudioStreamRenderer as streaming mode and reduce sample length of AudioClip. And also I adjusted audio transport timing accurately in AudioDeviceModule.

유저 리포팅 및 대응으로 인해 머지가 늦어져서, 수정사항을 우리 쪽 저장소에 선 반영합니다.